### PR TITLE
docs(README.md): fix example of GTINX usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ this package has a fairly narrow scope and is used in conjunction with an [Ionic
         readers: [
             Symbologies.Code39,
             Symbologies.ITF8,
-            Symbologies.GTINX
+            ...Symbologies.GTINX // This spreads to support all GTIN lengths 8-14
         ],
         readerConfigurations: [
             {


### PR DESCRIPTION
example use of GTINX was incorrect and would not compile, added spread operator and explanation

closes #2